### PR TITLE
added parameter request_timeout and http_proxy

### DIFF
--- a/install.en.md
+++ b/install.en.md
@@ -128,7 +128,7 @@ You can set a script path by `chain_ssh_wrapper` to retrieve SSH public key from
 
 `ssl_verify` tells if the client must verify or not the TLS certificate in the negotiation process with STNS server. If `false` is set, the client ignores the verification error of TLS certificate.
 
-You can set a url by `http_proxy` or environment valiable `HTTP_PROXY` to Proxy used for the HTTP request.
+You can set a URL of HTTP proxy server by `http_proxy` or by the environment valiable `HTTP_PROXY`.
 
 **Thirdly**, configure the name resolution order like below.
 

--- a/install.en.md
+++ b/install.en.md
@@ -116,6 +116,10 @@ wrapper_path      = "/usr/local/bin/stns-query-wrapper"
 chain_ssh_wrapper = "/usr/libexec/openssh/ssh-ldap-wrapper"
 
 ssl_verify        = true
+
+request_timeout = 3
+
+http_proxy = "http://your.proxy.com"
 ```
 
 This file configures the location of SNTS server, and the combination of id and password for basic authentication.
@@ -123,6 +127,8 @@ This file configures the location of SNTS server, and the combination of id and 
 You can set a script path by `chain_ssh_wrapper` to retrieve SSH public key from other place except for STNS server. STNS client executes the script with a user name as an argument.
 
 `ssl_verify` tells if the client must verify or not the TLS certificate in the negotiation process with STNS server. If `false` is set, the client ignores the verification error of TLS certificate.
+
+You can set a url by `http_proxy` or environment valiable `HTTP_PROXY` to Proxy used for the HTTP request.
 
 **Thirdly**, configure the name resolution order like below.
 

--- a/install.ja.md
+++ b/install.ja.md
@@ -103,10 +103,14 @@ wrapper_path = "/usr/local/bin/stns-query-wrapper"
 chain_ssh_wrapper = "/usr/libexec/openssh/ssh-ldap-wrapper"
 
 ssl_verify = true
+
+request_timeout = 3
+
+http_proxy = "http://your.proxy.com"
 ```
 
 設定としてはサーバのエンドポイント、ベーシック認証のID、パスワードを定義しています。`chain_ssh_wrapper`についてはSSHログイン時の公開鍵を取得する際にSTNSに加えて取得先がある場合に取得コマンドを定義します。定義されたコマンドに`ユーザー名`を引数に渡して取得を試みます。
-また`ssl_verify`についてはSTNSサーバをnginxなどと組み合わせてSSL対応した際に証明証の照合エラーを無視するか否かの設定です。`false`に設定した場合に証明証のエラーを無視します。
+`ssl_verify`についてはSTNSサーバをnginxなどと組み合わせてSSL対応した際に証明証の照合エラーを無視するか否かの設定です。`false`に設定した場合に証明証のエラーを無視します。プロキシサーバが必要な環境においては`http_proxy`もしくは環境変数`HTTP_PROXY`にプロキシサーバのURLを指定してください。
 
 * /etc/nssswitch.conf
 


### PR DESCRIPTION
add new parameter request_timeout and http_proxy

japanese
新しいパラメーターを追加しました。
request_timeoutでhttpリクエストのタイムアウトを指定可能にし、http_proxyでproxyサーバを指定可能にしました。