### PR TITLE
apiはバージョン2を標準にする

### DIFF
--- a/install.en.md
+++ b/install.en.md
@@ -106,7 +106,7 @@ $ service nscd reload
 `/etc/stns/libnss_stns.conf`:
 
 ```toml
-api_end_point     = ["http://<server-ip>:1104"]
+api_end_point     = ["http://<server-ip>:1104/v2"]
 
 user              = "test_user"
 password          = "test_password"

--- a/install.ja.md
+++ b/install.ja.md
@@ -93,7 +93,7 @@ $ service nscd reload
 
 
 ```toml
-api_end_point = ["http://<server-ip>:1104"]
+api_end_point = ["http://<server-ip>:1104/v2"]
 
 user = "test_user"
 password = "test_password"


### PR DESCRIPTION
libnss-snts側のapiバージョン指定をv2にします。