### PR TITLE
パスワードのハッシュ形式を/etc/shadow形式にします

### DIFF
--- a/advanced.en.md
+++ b/advanced.en.md
@@ -85,19 +85,9 @@ You can create a special user account for `sudo` like below. It can be considere
 `/etc/stns/stns.conf`:
 
 ```toml
-salt_enable       = true
-stretching_number = 100000
-
 [sudoers.example]
-password          = "a3b20fc634ac4bad5be8a40566acb00adcd2e5bf2fb9be4750150553d529b799"
-hash_type         = "sha256"
+password = "$6$ZbcEUwqLWMcV7fr5$4krw.1ULrmZytoMwuV5.pIqjEo1Ngc9K15zYQ.KGZa.8T4EmCd1RfUM6rfviIpAwncNpnF9Yjyc0.30c2dN1J/"
 ```
-
-The configuration above:
-
-* Enables salt and does 100 thousands of stretching to secure the password
-* Utilizes SHA256 algorithm to hash the password (`hash_type` can be set to `sha256` or `sha512`)
-
 You can use [stns-passwd](https://github.com/STNS/stns-passwd) to get such a hashed password.
 
 ##### Client
@@ -133,8 +123,7 @@ You can also set hashed passwords for each users like below:
 id        = 1000
 group_id  = 1000
 directory = "/home/example"
-password  = "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
-hash_type = "sha256"
+password = "$6$ZbcEUwqLWMcV7fr5$4krw.1ULrmZytoMwuV5.pIqjEo1Ngc9K15zYQ.KGZa.8T4EmCd1RfUM6rfviIpAwncNpnF9Yjyc0.30c2dN1J/"
 ```
 
 ##### Client

--- a/advanced.ja.md
+++ b/advanced.ja.md
@@ -66,24 +66,20 @@ STNSでは2種類の方法でsudoのパスワードを管理することが出�
 #### sudo専用のアカウントを利用する
 STNSにsudo用のアカウントを設け、パスワードを管理することが出来ます。イメージとしては第2のrootパスワードです。
 
-下記のようにサーバにsudo用の定義を行います。下記の例ではSaltを有効にし、10万回のストレッチングを行っています。
+下記のようにサーバにsudo用の定義を行います。
 
 * /etc/stns/stns.conf
 
 ```toml
-salt_enable = true
-stretching_number = 100000
-
 [sudoers.example]
-password = "a3b20fc634ac4bad5be8a40566acb00adcd2e5bf2fb9be4750150553d529b799"
-hash_type = "sha256"
+password = "$6$ZbcEUwqLWMcV7fr5$4krw.1ULrmZytoMwuV5.pIqjEo1Ngc9K15zYQ.KGZa.8T4EmCd1RfUM6rfviIpAwncNpnF9Yjyc0.30c2dN1J/"
 ```
 
-`hash_type`には`sha256`と`sha512`が指定可能です。パスワードハッシュについては[stns-passwd](https://github.com/STNS/stns-passwd)コマンドを利用してください。
+パスワードハッシュについては[stns-passwd](https://github.com/STNS/stns-passwd)コマンドを利用してください。
 
 ```
-$ stns-passwd -s example -c 1000000 p@ssword
-a3b20fc634ac4bad5be8a40566acb00adcd2e5bf2fb9be4750150553d529b799
+$ stns-passwd p@ssword
+$6$ZbcEUwqLWMcV7fr5$4krw.1ULrmZytoMwuV5.pIqjEo1Ngc9K15zYQ.KGZa.8T4EmCd1RfUM6rfviIpAwncNpnF9Yjyc0.30c2dN1J/
 ```
 
 次にクライアントのpamの設定を行います。
@@ -111,8 +107,7 @@ STNSではユーザーごとにパスワードハッシュを定義すること�
 id = 1000
 group_id = 1000
 directory = "/home/example"
-password = "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"
-hash_type = "sha256"
+password = "$6$ZbcEUwqLWMcV7fr5$4krw.1ULrmZytoMwuV5.pIqjEo1Ngc9K15zYQ.KGZa.8T4EmCd1RfUM6rfviIpAwncNpnF9Yjyc0.30c2dN1J/"
 ```
 
 このように定義した状態でクライアント側のpamを下記のように定義します。

--- a/configuration.en.md
+++ b/configuration.en.md
@@ -18,9 +18,6 @@ uid=1001(pyama) gid=1001(pyama) groups=1001(pyama)
 ```toml
 port = 1104
 include = "/etc/stns/conf.d/*"
-salt_enable = false
-stretching_number = 0
-hash_type = "sha256"
 
 # support basic auth
 user = "basic_user"
@@ -39,8 +36,7 @@ id = 1001
 users = ["example"]
 
 [sudoers.example]
-password = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
-hash_type = "sha256"
+password = "$6$ZbcEUwqLWMcV7fr5$4krw.1ULrmZytoMwuV5.pIqjEo1Ngc9K15zYQ.KGZa.8T4EmCd1RfUM6rfviIpAwncNpnF9Yjyc0.30c2dN1J/"
 ```
 
 ### General
@@ -51,9 +47,6 @@ hash_type = "sha256"
 |include|include config directory|
 |user| basic authentication user|
 |password| basic authentication password|
-|salt_enable| To generate a salt of the password from the user name |
-|stretching_number|Stretching number of password|
-|hash_type| password hash algorithm (sha256,sha512) |
 
 ### Users
 
@@ -67,7 +60,6 @@ hash_type = "sha256"
 |keys|public key list|
 |link_users|merge public key from the specified user|
 |password| password token|
-|hash_type| hash algorithm (sha256,sha512) Users > General|
 
 #### link_users
 
@@ -128,7 +120,5 @@ $ /user/local/bin/stns-query-wrapper /group/name/division
 |Name|Description|
 |---|---|
 |password(※)| password token|
-|hash_type| hash algorithm default sha256(sha256,sha512) |
 
 ※: required parameter
-

--- a/install.en.md
+++ b/install.en.md
@@ -161,7 +161,7 @@ $ /usr/sbin/nscd -i passwd
 
 ```
 PubkeyAuthentication yes
-AuthorizedKeysCommand /usr/local/bin/stns-key-wrapper
+AuthorizedKeysCommand /usr/lib/stns/stns-key-wrapper
 AuthorizedKeysCommandUser root
 ```
 

--- a/install.ja.md
+++ b/install.ja.md
@@ -139,7 +139,7 @@ $ /usr/sbin/nscd -i passwd
 
 ```
 PubkeyAuthentication yes
-AuthorizedKeysCommand /usr/local/bin/stns-key-wrapper
+AuthorizedKeysCommand /usr/lib/stns/stns-key-wrapper
 AuthorizedKeysCommandUser root
 ```
 


### PR DESCRIPTION
独自実装を行っていたパスワードハッシュの形式を/etc/shadow形式としました。
マイナーバージョンを上げてリリースし、セキュリティに関わる部分なので下位互換は持ちません。